### PR TITLE
Recurrence and composed_of

### DIFF
--- a/lib/recurrence/namespace.rb
+++ b/lib/recurrence/namespace.rb
@@ -10,6 +10,26 @@ module SimplesIdeias
 
     attr_reader :event, :options
 
+    def self.default_starts_date
+      if @default_starts_date
+        if @default_starts_date.is_a?(String)
+          eval(@default_starts_date)
+        else
+          @default_starts_date.call
+        end
+      else
+        Date.today
+      end
+    end
+
+    def self.default_starts_date=(date)
+      unless date.respond_to?(:call) || date.is_a?(String) || date == nil
+        raise ArgumentError, 'default_starts_date must be a proc or an evaluatable string such as "Date.current"'
+      end
+
+      @default_starts_date = date
+    end
+
     def self.default_until_date
       @default_until_date ||= Date.new(2037, 12, 31)
     end
@@ -136,7 +156,7 @@ module SimplesIdeias
         options[name] = Date.parse(options[name]) if options[name].is_a?(String)
       end
 
-      options[:starts] ||= Date.today
+      options[:starts] ||= self.class.default_starts_date
       options[:until]  ||= self.class.default_until_date
 
       options

--- a/spec/recurrence_spec.rb
+++ b/spec/recurrence_spec.rb
@@ -33,6 +33,44 @@ describe "recurrence" do
     expect { recurrence(:every => :month, :on => 10, :interval => :invalid) }.to raise_error(ArgumentError)
   end
 
+  describe '.default_starts_date' do
+    it 'should return Date.today by default' do
+      Recurrence.default_starts_date.should == Date.today
+    end
+
+    it 'should require only strings and procs' do
+      expect { Recurrence.default_starts_date = Date.tomorrow }.to raise_error(ArgumentError)
+    end
+
+    context 'when .default_starts_date is reassigned to "Date.tomorrow" string' do
+      before { Recurrence.default_starts_date = 'Date.tomorrow' }
+      after { Recurrence.default_starts_date = nil }
+
+      it 'should return Date.tomorrow' do
+        Recurrence.default_starts_date.should == Date.tomorrow
+      end
+
+      it 'should have effect on generated events' do
+        r = Recurrence.new(:every => :day, :until => 3.days.from_now.to_date)
+        r.events.first.should == Date.tomorrow
+      end
+    end
+
+    context 'when .default_starts_date is reassigned to lambda { Date.tomorrow } proc' do
+      before { Recurrence.default_starts_date = lambda { Date.tomorrow } }
+      after { Recurrence.default_starts_date = nil }
+
+      it 'should return Date.tomorrow' do
+        Recurrence.default_starts_date.should == Date.tomorrow
+      end
+
+      it 'should have effect on generated events' do
+        r = Recurrence.new(:every => :day, :until => 3.days.from_now.to_date)
+        r.events.first.should == Date.tomorrow
+      end
+    end
+  end
+
   context "with daily recurring" do
     it "should recur until limit date" do
       @recurrence = Recurrence.daily


### PR DESCRIPTION
When using recurrence with ActiveRecord, wouldn't it be convenient to use composed_of?

The docs suggest we should do something like:

```
options = {:every => :day}

@task.recurrence_options = options
Recurrence.new(@task.recurrence_options)
```

Instead we could have

```
 @task.recurrence = Recurrence.new(:every => :day)
 @task.recurrence # => <Recurrence>
```

But for that we need to map recurrence attribute to some reader method on Recurrence, such as #options. See commit message for example.
