### PR TITLE
Fix gemspec and VERSION requirements for fresh installs

### DIFF
--- a/recurrence.gemspec
+++ b/recurrence.gemspec
@@ -1,10 +1,10 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require "recurrence"
+require 'recurrence/version'
 
 Gem::Specification.new do |s|
   s.name        = "recurrence"
-  s.version     = Recurrence::Version::STRING
+  s.version     = SimplesIdeias::Recurrence::Version::STRING
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Nando Vieira"]
   s.email       = ["fnando.vieira@gmail.com"]


### PR DESCRIPTION
When starting development on this project, using an empty gemset, Bundler is unable to install with the following error:

``` bash
$ bundle
There was a LoadError while evaluating recurrence.gemspec:
  no such file to load -- active_support/core_ext from
  /Users/nate/code/fnando/recurrence/recurrence.gemspec:3:in `<main>'

Does it try to require a relative path? That doesn't work in Ruby 1.9.
```

This is due to the `require 'recurrence'` call in the gemspec, which requires active_support, which is not yet installed (again, with an empty gemset).  So, to fix this issue, I require 'recurrence/version' instead and simplified the VERSION definition.
