### PR TITLE
Add date shifting around boundary days

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -62,6 +62,9 @@ A simple library to handle recurring events.
   # Override the next date handler
   r = Recurrence.new(:every => :month, :on => 1, :handler => Proc.new { |day, month, year| raise("Date not allowed!") if year == 2011 && month == 12 && day == 31 })
 
+  # Shift the recurrences to maintain dates around boundaries (Jan 31 -> Feb 28 -> Mar 28)
+  r = Recurrence.new(:every => :month, :on => 31, :shift => true)
+
   # Getting an array with all events
   r.events.each {|date| puts date.to_s }  # => Memoized array
   r.events!.each {|date| puts date.to_s } # => reset items cache and re-execute it

--- a/lib/recurrence/event/base.rb
+++ b/lib/recurrence/event/base.rb
@@ -36,6 +36,7 @@ module SimplesIdeias
           @date = next_in_recurrence
 
           @finished, @date = true, nil if @date > @options[:until]
+          shift_to @date if @date && @options[:shift]
           @date
         end
 
@@ -85,6 +86,10 @@ module SimplesIdeias
             raise ArgumentError, "invalid weekday #{value}" unless weekday
             weekday
           end
+        end
+
+        def shift_to(date)
+          # no-op
         end
       end
     end

--- a/lib/recurrence/event/monthly.rb
+++ b/lib/recurrence/event/monthly.rb
@@ -86,6 +86,10 @@ module SimplesIdeias
           @options[:handler].call(date.day, date.month, date.year)
         end
 
+        def shift_to(date)
+          @options[:on] = date.day
+        end
+
         private
         def valid_cardinal?(cardinal)
           raise ArgumentError, "invalid cardinal #{cardinal}" unless CARDINALS.include?(cardinal.to_s)

--- a/lib/recurrence/event/yearly.rb
+++ b/lib/recurrence/event/yearly.rb
@@ -46,6 +46,10 @@ module SimplesIdeias
           @options[:handler].call(@options[:on].last, next_month, next_year)
         end
 
+        def shift_to(date)
+          @options[:on] = [date.month, date.day]
+        end
+
         private
         def valid_month?(month)
           raise ArgumentError, "invalid month #{month}" unless (1..12).include?(month)

--- a/spec/recurrence_spec.rb
+++ b/spec/recurrence_spec.rb
@@ -788,6 +788,55 @@ describe Recurrence do
     end
   end
 
+  context "with shifting enabled" do
+    it "shifts yearly recurrences around February 29" do
+      r = recurrence(:every => :year, :starts => '2012-02-29', :on => [2,29], :shift => true)
+      r.events[0].should == Date.new(2012, 2, 29)
+      r.events[1].should == Date.new(2013, 2, 28)
+      r.events[2].should == Date.new(2014, 2, 28)
+      r.events[3].should == Date.new(2015, 2, 28)
+      r.events[4].should == Date.new(2016, 2, 28)
+    end
+
+    it "shifts monthly recurrences around the 31st" do
+      r = recurrence(:every => :month, :starts => '2011-01-31', :on => 31, :shift => true)
+      r.events[0].should == Date.new(2011, 1, 31)
+      r.events[1].should == Date.new(2011, 2, 28)
+      r.events[2].should == Date.new(2011, 3, 28)
+    end
+
+    it "shifts monthly recurrences around the 30th" do
+      r = recurrence(:every => :month, :starts => '2011-01-30', :on => 30, :shift => true)
+      r.events[0].should == Date.new(2011, 1, 30)
+      r.events[1].should == Date.new(2011, 2, 28)
+      r.events[2].should == Date.new(2011, 3, 28)
+    end
+
+    it "shifts monthly recurrences around the 29th" do
+      r = recurrence(:every => :month, :starts => '2011-01-29', :on => 29, :shift => true)
+      r.events[0].should == Date.new(2011, 1, 29)
+      r.events[1].should == Date.new(2011, 2, 28)
+      r.events[2].should == Date.new(2011, 3, 28)
+
+      r = recurrence(:every => :month, :starts => '2012-01-29', :on => 29, :shift => true)
+      r.events[0].should == Date.new(2012, 1, 29)
+      r.events[1].should == Date.new(2012, 2, 29)
+      r.events[2].should == Date.new(2012, 3, 29)
+    end
+
+    it "correctly resets to original day for monthly" do
+      r = recurrence(:every => :month, :starts => '2011-01-31', :on => 31, :shift => true)
+      r.next!; r.next!
+      expect { r.reset! }.to change(r, :next).from(Date.new(2011, 2, 28)).to(Date.new(2011, 1, 31))
+    end
+
+    it "correctly resets to original month and day for yearly" do
+      r = recurrence(:every => :year, :starts => '2012-02-29', :on => [2,29], :shift => true)
+      r.next!; r.next!
+      expect { r.reset! }.to change(r, :next).from(Date.new(2013, 2, 28)).to(Date.new(2012, 2, 29))
+    end
+  end
+
   private
   def recurrence(options)
     Recurrence.new(options)


### PR DESCRIPTION
This patch extends Recurrence to optionally shift the day of recurrence when boundary dates occur.  Examples of the functionality are below:

Current (still the default after this patch):

``` ruby
r = SimplesIdeias::Recurrence.monthly(:on => 31, :repeat => 10)
y r.events
# ---
# - 2011-08-31
# - 2011-09-30
# - 2011-10-31
# - 2011-11-30
# - 2011-12-31
# - 2012-01-31
# - 2012-02-29
# - 2012-03-31
# - 2012-04-30
# - 2012-05-31
```

After the patch, using the `:shift` option:

``` ruby
r = SimplesIdeias::Recurrence.monthly(:on => 31, :repeat => 10, :shift => true)
y r.events
# ---
# - 2011-08-31
# - 2011-09-30
# - 2011-10-30
# - 2011-11-30
# - 2011-12-30
# - 2012-01-30
# - 2012-02-29
# - 2012-03-29
# - 2012-04-29
# - 2012-05-29
```

So, the August 31st is the first event, the next event would happen on Sept 31st, but that's beyond the boundary, so it shifts back to the 30th (as defined by the default `:handler`).  With the `:shift` option enabled, all future events now move to the 30th, as well.  So Oct 30, Nov 30, Dec 30, Jan 30.  But then Feb doesn't have a 30th, so the handler dictates it back to the 29th.  Shift stores the 29th going forward, and things contine.
