### PR TITLE
Use “ordinal” instead of “cardinal” since it fits the semantics better

### DIFF
--- a/lib/recurrence/event/base.rb
+++ b/lib/recurrence/event/base.rb
@@ -2,7 +2,7 @@ module SimplesIdeias
   class Recurrence
     module Event # :nodoc: all
       class Base
-        CARDINALS = %w(first second third fourth fifth)
+        ORDINALS = %w(first second third fourth fifth)
         WEEKDAYS = {
           "sun" => 0, "sunday"    => 0,
           "mon" => 1, "monday"    => 1,

--- a/lib/recurrence/event/monthly.rb
+++ b/lib/recurrence/event/monthly.rb
@@ -19,8 +19,8 @@ module SimplesIdeias
             elsif @options[:on].kind_of?(Numeric)
               valid_week?(@options[:on])
             else
-              valid_cardinal?(@options[:on])
-              @options[:on] = CARDINALS.index(@options[:on].to_s) + 1
+              valid_ordinal?(@options[:on])
+              @options[:on] = ORDINALS.index(@options[:on].to_s) + 1
             end
 
             @options[:weekday] = valid_weekday_or_weekday_name?(@options[:weekday])
@@ -91,12 +91,12 @@ module SimplesIdeias
         end
 
         private
-        def valid_cardinal?(cardinal)
-          raise ArgumentError, "invalid cardinal #{cardinal}" unless CARDINALS.include?(cardinal.to_s)
+        def valid_ordinal?(ordinal)
+          raise ArgumentError, "invalid ordinal #{ordinal}" unless ORDINALS.include?(ordinal.to_s)
         end
 
         def valid_interval?(interval)
-          raise ArgumentError, "invalid cardinal #{interval}" unless INTERVALS.key?(interval)
+          raise ArgumentError, "invalid ordinal #{interval}" unless INTERVALS.key?(interval)
         end
 
         def valid_week?(week)


### PR DESCRIPTION
Don't take this as something snobbish :smiley: 

> A Cardinal Number is a number that says how many of something there are, such as one, two, three, four, five. A Cardinal Number answers the question "How Many?"

Since we're rather answering to **Which one?** with `:first`, `:second`, etc., I thought renaming the constant and the validator methods to use `ordinal` instead of `cardinal` to match the semantics might be a tiny little improvement.
