### PR TITLE
Switching references of Date.today to Date.current

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,21 @@ r = Recurrence.new(:every => :year, :on => [10, 31], :repeat => 3)
 r = Recurrence.yearly(:on => [:january, 31])
 
 # Limit recurrence
-# :starts defaults to Date.today
+# :starts defaults to Date.current
 # :until defaults to 2037-12-31
-r = Recurrence.new(:every => :day, :starts => Date.today)
+r = Recurrence.new(:every => :day, :starts => Date.current)
 r = Recurrence.new(:every => :day, :until => '2010-01-31')
-r = Recurrence.new(:every => :day, :starts => Date.today, :until => '2010-01-31')
+r = Recurrence.new(:every => :day, :starts => Date.current, :until => '2010-01-31')
 
 # Generate a collection of events which always includes a final event with the given through date
 # :through defaults to being unset
 r = Recurrence.new(:every => :day, :through => '2010-01-31')
-r = Recurrence.new(:every => :day, :starts => Date.today, :through => '2010-01-31')
+r = Recurrence.new(:every => :day, :starts => Date.current, :through => '2010-01-31')
 
 # Remove a date in the series on the given except date(s)
 # :except defaults to being unset
 r = Recurrence.new(:every => :day, :except => '2010-01-31')
-r = Recurrence.new(:every => :day, :except => [Date.today, '2010-01-31'])
+r = Recurrence.new(:every => :day, :except => [Date.current, '2010-01-31'])
 
 # Override the next date handler
 r = Recurrence.new(:every => :month, :on => 1, :handler => Proc.new { |day, month, year| raise("Date not allowed!") if year == 2011 && month == 12 && day == 31 })
@@ -94,7 +94,7 @@ r.each { |date| puts date.to_s } # => Use items method
 r.each! { |date| puts date.to_s } # => Use items! method
 
 # Check if a date is included
-r.include?(Date.today) # => true or false
+r.include?(Date.current) # => true or false
 r.include?('2008-09-21')
 
 # Get next available date
@@ -105,6 +105,8 @@ r.next! # => Change the internal date object to the next available date
 ## Troubleshooting
 
 If you're having problems because already have a class/module called Recurrence that is conflicting with this gem, you can require the namespace and create a class that inherits from `Recurrence_`.
+
+Using Date.today can cause issues because it doesn't use Time.zone whereas Time.tomorrow and Time.yesterday do.  Date.current is the equivalent that uses Time.zone.    Otherwise in specific timezones Date.today can equal Date.yesterday and Date.today can equal Date.tomorrow in others.
 
 ```ruby
 require "recurrence/namespace"

--- a/lib/recurrence/namespace.rb
+++ b/lib/recurrence/namespace.rb
@@ -28,15 +28,15 @@ class Recurrence_
     when Proc
       @default_starts_date.call
     else
-      Date.today
+      Date.current
     end
   end
 
   # Set the default starting date globally.
   # Can be a proc or a string.
   #
-  #   Recurrence.default_starts_date = proc { Date.today }
-  #   Recurrence.default_starts_date = "Date.today"
+  #   Recurrence.default_starts_date = proc { Date.current }
+  #   Recurrence.default_starts_date = "Date.current"
   #
   def self.default_starts_date=(date)
     unless date.respond_to?(:call) || date.kind_of?(String) || date == nil

--- a/test/recurrence/default_starts_date_test.rb
+++ b/test/recurrence/default_starts_date_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
 class DefaultStartsDateTest < Minitest::Test
-  test "returns Date.today by default" do
-    assert_equal Date.today, Recurrence.default_starts_date
+  test "returns Date.current by default" do
+    assert_equal Date.current, Recurrence.default_starts_date
   end
 
   test "requires only strings and procs" do

--- a/test/recurrence/except_test.rb
+++ b/test/recurrence/except_test.rb
@@ -9,7 +9,7 @@ class ExceptTest < Minitest::Test
   test "skips day specified in except" do
     r = recurrence(:every => :day, :except => Date.tomorrow)
 
-    assert r.include?(Date.today)
+    assert r.include?(Date.current)
     refute r.include?(Date.tomorrow)
     assert r.include?(Date.tomorrow + 1.day)
   end
@@ -17,7 +17,7 @@ class ExceptTest < Minitest::Test
   test "skips multiple days specified in except" do
     r = recurrence(:every => :day, :except => [Date.tomorrow, "2012-02-29"])
 
-    assert r.include?(Date.today)
+    assert r.include?(Date.current)
     refute r.include?(Date.tomorrow)
     refute r.include?("2012-02-29")
   end

--- a/test/recurrence/monthly_recurring/day_test.rb
+++ b/test/recurrence/monthly_recurring/day_test.rb
@@ -136,7 +136,7 @@ class MonthlyRecurringDayTest < Minitest::Test
   end
 
   test "uses except" do
-    r = recurrence(:every => :month, :on => Date.today.day, :except => 8.months.from_now.to_date)
+    r = recurrence(:every => :month, :on => Date.current.day, :except => 8.months.from_now.to_date)
 
     assert r.events.include?(7.months.from_now.to_date)
     refute r.events.include?(8.months.from_now.to_date)

--- a/test/recurrence/recurrence_test.rb
+++ b/test/recurrence/recurrence_test.rb
@@ -31,14 +31,14 @@ class RecurrenceTest < Minitest::Test
   test "returns next date" do
     r = recurrence(:every => :day)
 
-    assert_equal Date.today.to_s, r.next.to_s
-    assert_equal Date.today.to_s, r.next.to_s
+    assert_equal Date.current.to_s, r.next.to_s
+    assert_equal Date.current.to_s, r.next.to_s
   end
 
   test "returns next date and advance internal state" do
     r = recurrence(:every => :day)
 
-    assert_equal Date.today.to_s, r.next!.to_s
+    assert_equal Date.current.to_s, r.next!.to_s
     assert_equal 1.day.from_now.to_date.to_s, r.next!.to_s
     assert_equal 2.days.from_now.to_date.to_s, r.next!.to_s
     assert_equal 3.days.from_now.to_date.to_s, r.next!.to_s


### PR DESCRIPTION
Date.today doesn't take into account Time.zone and will throw off the recurrence
results in specific hours of the day.

Date.today can equal Date.tomorrow in +tz
Date.today can equal Date.yesterday in -tz

Recurrence.monthly(on: Date.yesterday.day, interval: 6).next #=> Wed, 05 Jun 2019
Recurrence.monthly(on: Date.current.day, interval: 6).next #=> Thu, 06 Dec 2018

that can give quite different results with recurrence