### PR TITLE
[BUG] Reset @finished attribute on `reset!`

### DIFF
--- a/lib/recurrence/event/base.rb
+++ b/lib/recurrence/event/base.rb
@@ -47,6 +47,7 @@ class Recurrence_
 
       def reset!
         @date = nil
+        @finished = false
       end
 
       def finished?

--- a/test/recurrence/recurrence_test.rb
+++ b/test/recurrence/recurrence_test.rb
@@ -22,6 +22,17 @@ class RecurrenceTest < Minitest::Test
     assert_equal "2008-02-29", r.next.to_s
   end
 
+  test "resets to the first available date even when the event iterator is finished" do
+    r = recurrence(:every => :month, :on => 1, :starts => "2008-01-01", :until => "2008-01-01")
+
+    assert_equal "2008-01-01", r.next!.to_s
+    assert_nil r.next!
+
+    r.reset!
+
+    assert_equal "2008-01-01", r.next!.to_s
+  end
+
   test "returns passed-in options" do
     r = recurrence(:every => :day)
     options = {every: :day}


### PR DESCRIPTION
To reproduce the issue, try the following:

```ruby
$ r = Recurrence.new(every: 'month', starts: Date.today, on: Date.today.day)
$ r.events(starts: Date.today)
=> [Fri, 29 Nov 2019,
 Sun, 29 Dec 2019,
 Wed, 29 Jan 2020,
 Sat, 29 Feb 2020,
# ...
$ r.events(starts: Date.today)
=> []
```

Expected outcome: `r.events(starts: Date.today)` should be idempotent. Instead, the @finished value is set on the @event, causing subsequent `.events` calls to return an empty array.