### PR TITLE
Fixes typo that stops the ArgumentError if @options[:on] is missing

### DIFF
--- a/lib/recurrence/event/yearly.rb
+++ b/lib/recurrence/event/yearly.rb
@@ -19,7 +19,7 @@ class Recurrence_
       }.freeze
 
       private def validate
-        valid_month_day?(@options[:on].last)
+        valid_month_day?(@options[:on]&.last)
 
         if @options[:on].first.is_a?(Numeric)
           valid_month?(@options[:on].first)


### PR DESCRIPTION
Fixes typo that stops the `ArgumentError` triggered by `valid_month_day` if `@options[:on]` is `nil` on an yearly recurrence.