### PR TITLE
Fix bug with weekday option not working as expected when shift is enabled

### DIFF
--- a/lib/recurrence/event/monthly.rb
+++ b/lib/recurrence/event/monthly.rb
@@ -105,7 +105,7 @@ class Recurrence_
       end
 
       private def shift_to(date)
-        @options[:on] = date.day
+        @options[:on] = date.day unless @options[:weekday].present?
       end
 
       private def valid_ordinal?(ordinal)

--- a/test/recurrence/date_shift_test.rb
+++ b/test/recurrence/date_shift_test.rb
@@ -70,4 +70,13 @@ class DateShiftTest < Minitest::Test
 
     assert_equal Date.new(2012, 2, 29), r.next
   end
+
+  test "correctly recurrs for weekdays" do
+    r = recurrence(every: :month, starts: "2011-01-31", on: "first",
+                   weekday: "monday", shift: true)
+
+    assert_equal Date.new(2011, 2, 7), r.events[0]
+    assert_equal Date.new(2011, 3, 7), r.events[1]
+    assert_equal Date.new(2011, 4, 4), r.events[2]
+  end
 end


### PR DESCRIPTION
Hey Nando,

Thank you for the wonderful gem, we have been using it for years and it's really useful.

@pmrazovic has noticed a bug with how it handles `weekday` option when `shift` is enabled, so this PR fixes it.
We give users access to specify the rules for recurrence so we generally always want to enable `shift`.

Without the fix these are the first three Recurrence events for

```ruby
r = Recurrence.new(every: :month, starts: "2011-01-31", on: "first", weekday: "monday", shift: true)
r.events
```
```
2011-02-07 ← first Monday of the month
2011-03-28 ← not the first Monday of the month
2011-09-26 ← not the first Monday of the month
```

This is with the fix:

```
2011-02-07 ←  first Monday of the month
2011-03-07 ←  first Monday of the month
2011-04-04 ←  first Monday of the month
```

